### PR TITLE
fix: add nest_asyncio to dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
     "msal",
     "playwright",
     "pystac_client",
-    "requests-oauthlib"
+    "requests-oauthlib",
+    "nest_asyncio",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
fixes #368