### PR TITLE
fix: switched tensorflow-cpu to tensorflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pystac_client",
     "requests-oauthlib",
     "nest_asyncio",
-    "tensorflow-cpu"
+    "tensorflow"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
fixes #372

In my local, by switching to tensorflow from tensorflow-cpu, it increases size for 6.38GB > 6.43GB. I think it is acceptable