### PR TITLE
fix: improve search daterange, and handle nodata value for prediction and downloaded data correctly

### DIFF
--- a/rapida/cli/assess.py
+++ b/rapida/cli/assess.py
@@ -117,7 +117,9 @@ def build_variable_help():
               type=str, callback=validate_variables,
               help=f"{build_variable_help()}")
 @click.option('--year', '-y', required=False, type=int, multiple=False,default=datetime.datetime.now().year,
-              show_default=True,help=f'The year for which to compute population' )
+              show_default=True,help=f'The year for which to compute population and landuse' )
+@click.option('--month', '-m', required=False, type=int, multiple=False,default=None,
+              show_default=True,help=f"Optional. The end month for which to compute landuse. \nIf this is used together with --year, it searches data until target year and month for the last 6 months. \nIf this is used without --year, and it is future month, current month is used as end month.")
 @click.option('-p', '--project',
               default=None,
               type=click.Path(file_okay=False, dir_okay=True, resolve_path=True),
@@ -130,7 +132,7 @@ def build_variable_help():
               help="Set log level to debug"
               )
 @click.pass_context
-def assess(ctx, all=False, components=None,  variables=None, year=None, project: str = None, force=False, debug=False):
+def assess(ctx, all=False, components=None,  variables=None, year=None, month=None, project: str = None, force=False, debug=False):
     """
     Assess/evaluate a specific geospatial exposure components/variables
 
@@ -208,7 +210,7 @@ def assess(ctx, all=False, components=None,  variables=None, year=None, project:
                 cls = import_class(fqcn=fqcn)
                 component = cls()
 
-                component(progress=progress, variables=variables, target_year=year, force=force)
+                component(progress=progress, variables=variables, target_year=year, target_month=month, force=force)
 
 
 

--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -11,7 +11,7 @@ import geopandas as gpd
 from rapida.components.landuse.stac import interpolate_stac_source, download_stac
 from rapida.components.landuse.prediction import predict
 from rapida.components.landuse.constants import STAC_MAP
-from rapida.constants import GTIFF_CREATION_OPTIONS
+from rapida.constants import GTIFF_CREATION_OPTIONS, POLYGONS_LAYER_NAME
 from rapida.core.component import Component
 from rapida.core.variable import Variable
 from rapida.project.project import Project
@@ -307,7 +307,7 @@ class LanduseVariable(Variable):
         if dst_layer in lnames:
             polygons_layer = dst_layer
         else:
-            polygons_layer = constants.POLYGONS_LAYER_NAME
+            polygons_layer = POLYGONS_LAYER_NAME
         if self.operator:
             assert os.path.exists(self.local_path), f'{self.local_path} does not exist'
 

--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -24,7 +24,7 @@ logger = logging.getLogger('rapida')
 
 
 class LanduseComponent(Component):
-    def __call__(self, variables: List[str], target_year: int=None, **kwargs):
+    def __call__(self, variables: List[str], target_year: int=None, target_month: int=None, **kwargs):
         if not variables:
             variables = self.variables
         else:
@@ -43,6 +43,7 @@ class LanduseComponent(Component):
                     name=var_name,
                     component=self.component_name,
                     target_year=target_year,
+                    target_month=target_month,
                     **var_data
                 )
                 v(**kwargs)
@@ -165,6 +166,7 @@ class LanduseVariable(Variable):
                           polygons_layer_name=project.polygons_layer_name,
                           output_dir=output_dir,
                           target_year=self.target_year,
+                          target_month=self.target_month,
                           target_assets=self.target_asset,
                           target_srs=project.target_srs,
                           progress=progress))

--- a/rapida/components/landuse/prediction.py
+++ b/rapida/components/landuse/prediction.py
@@ -154,8 +154,17 @@ def predict(img_paths: List[str], output_file_path: str, progress = None):
     if predict_task is not None:
         progress.update(predict_task, description=f"[cyan]Creating output file: {output_file_path}")
 
-    with rasterio.open(output_file_path, mode='w', driver="GTiff", dtype='uint8',
-                       width=col_size, height=row_size, crs=crs, transform=dst_transform, count=1) as dst:
+    with rasterio.open(output_file_path,
+                       mode='w',
+                       driver="GTiff",
+                       dtype='uint8',
+                       width=col_size,
+                       height=row_size,
+                       crs=crs,
+                       transform=dst_transform,
+                       count=1,
+                       compress='ZSTD',
+                       tiled=True) as dst:
         tasks = []
         with ProcessPoolExecutor() as executor:
             for row in range(0, row_size, 256):

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -7,6 +7,8 @@ from glob import glob
 from collections import defaultdict
 import concurrent.futures
 import threading
+from typing import Optional
+from calendar import monthrange
 
 from osgeo import gdal
 from datetime import datetime, date
@@ -43,18 +45,69 @@ def interpolate_stac_source(source: str) -> dict[str, str]:
     }
 
 
-def create_date_range(target_year: int) -> str:
+def create_date_range(target_year: int, target_month: Optional[int] = None, duration: int = 6) -> str:
     """
-    create date range from start date to end date for a given target year
+    Generate a date range string in the format 'YYYY-MM-DD/YYYY-MM-DD'.
 
-    :param target_year: target year
-    :return: date range formatted as YYYY-MM-DD/YYYY-MM-DD. But maximum date is always today's date.
+    The end date is determined based on the provided target year and optional target month:
+    - If target_year is None or in the future → use current year.
+    - If target_month is None:
+        - If target_year is current year → use today as end_date.
+        - If target_year is past → use December as default month.
+    - If target_month is in the future (within current year) → clamp to current month.
+    - end_date = today (if current year and current/future month), else last day of target_month.
+    - start_date = end_date - `duration` months (manual calculation, no external lib).
+
+    The start date is computed by subtracting `duration` months from the end date,
+    accounting for varying month lengths and year boundaries.
+
+    :param target_year: The year of interest.
+    :param target_month: The month of interest (1–12), optional.
+    :param duration: Number of months to go back from the end date (default is 6).
+    :return: A date range string in the format 'YYYY-MM-DD/YYYY-MM-DD'.
     """
-    start_date = date(target_year, 1, 1)
-    end_of_year = date(target_year, 12, 31)
     today = date.today()
+    current_year = today.year
+    current_month = today.month
 
-    end_date = min(today, end_of_year)
+    def subtract_months(from_date: date, months: int) -> date:
+        year = from_date.year
+        month = from_date.month - months
+
+        while month <= 0:
+            month += 12
+            year -= 1
+
+        day = min(from_date.day, monthrange(year, month)[1])
+        return date(year, month, day)
+
+    # normalize year
+    if target_year is None or target_year > current_year:
+        target_year = current_year
+
+    # normalize month
+    if target_month is None:
+        if target_year < current_year:
+            target_month = 12  # Use December for past years
+    else:
+        if target_year == current_year and target_month > current_month:
+            target_month = current_month
+
+            # Determine end_date
+    if target_year == current_year:
+        if target_month is None or target_month >= current_month:
+            end_date = today
+        else:
+            last_day = monthrange(target_year, target_month)[1]
+            end_date = date(target_year, target_month, last_day)
+    else:
+        if target_month is None:
+            end_date = date(target_year, 12, 31)
+        else:
+            last_day = monthrange(target_year, target_month)[1]
+            end_date = date(target_year, target_month, last_day)
+
+    start_date = subtract_months(end_date, duration)
 
     return f"{start_date.strftime('%Y-%m-%d')}/{end_date.strftime('%Y-%m-%d')}"
 
@@ -360,7 +413,7 @@ def search_stac_items(stac_client,
 
     search_task = None
     if progress:
-        search_task = progress.add_task(f"[green]Searching STAC Items", total=len(df_polygon))
+        search_task = progress.add_task(f"[green]Searching STAC Items for {datetime_range}", total=len(df_polygon))
 
     latest_per_tile = {}
     lock = threading.Lock()
@@ -434,6 +487,7 @@ async def download_stac(
     polygons_layer_name: str,
     output_dir: str,
     target_year: int,
+    target_month:int,
     target_assets: dict[str, str],
     target_srs,
     progress: Progress = None,
@@ -468,12 +522,12 @@ async def download_stac(
     if progress and stac_task:
         progress.update(stac_task, description="[yellow]Searching for STAC items...")
 
-    datetime = create_date_range(target_year)
-
+    datetime_range = create_date_range(target_year, target_month)
+    logger.debug(f"datetime range for searching: {datetime_range}")
     latest_per_tile = search_stac_items(stac_client=client,
                       collection_id=collection_id,
                       df_polygon=df_polygon,
-                      datetime_range=datetime,
+                      datetime_range=datetime_range,
                       target_assets=target_assets,
                       progress=progress,)
 
@@ -491,7 +545,7 @@ async def download_stac(
                 asset_urls.append((asset.href, key, tile_id, no_data, item_datetime, cloud_cover))
 
     if not asset_urls:
-        raise RuntimeError(f"No assets found in {stac_url} for target area")
+        raise RuntimeError(f"No assets found for target area and date range: {datetime_range}")
 
     if progress and stac_task:
         progress.update(stac_task, description=f"[cyan]Preparing to download {len(asset_urls)} assets", total=len(asset_urls))
@@ -503,7 +557,7 @@ async def download_stac(
 
     semaphore = asyncio.Semaphore(max_workers)
 
-    async def download_asset(url, asset_key, tile_id, nodata, datetime,cloud_cover, semaphore):
+    async def download_asset(url, asset_key, tile_id, nodata, target_datetime,cloud_cover, semaphore):
         url = s3_to_http(url)
         band_name = target_assets[asset_key]
         asset_nodata[band_name] = nodata
@@ -524,7 +578,7 @@ async def download_stac(
                         target_srs=target_srs,
                         progress=progress,
                         no_data_value=nodata,
-                        item_datetime=datetime,
+                        item_datetime=target_datetime,
                         cloud_cover=cloud_cover,
                     )
                     if progress and stac_task:

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -19,6 +19,8 @@ from rasterio.warp import reproject, Resampling, calculate_default_transform
 from rasterio.crs import CRS
 import httpx
 import geopandas as gpd
+
+from rapida.constants import GTIFF_CREATION_OPTIONS
 from rapida.util import geo
 import time
 
@@ -374,6 +376,7 @@ def crop_asset_files(base_dir,
             return_handle=False,
             progress=progress,
             warpMemoryLimit=1024,
+            creationOptions=GTIFF_CREATION_OPTIONS,
         )
 
         if os.path.exists(vrt_path):

--- a/tests/rapida/components/landuse/test_stac.py
+++ b/tests/rapida/components/landuse/test_stac.py
@@ -1,0 +1,35 @@
+import pytest
+from datetime import date
+from rapida.components.landuse.stac import create_date_range
+from unittest.mock import patch
+
+@pytest.fixture
+def mock_today():
+    with patch("rapida.components.landuse.stac.date") as mock_date:
+        mock_date.today.return_value = date(2025, 5, 2)
+        mock_date.side_effect = lambda *args, **kwargs: date(*args, **kwargs)
+        yield
+
+def test_default_current_year(mock_today):
+    assert create_date_range(None) == "2024-11-02/2025-05-02"
+
+def test_future_year_becomes_current(mock_today):
+    assert create_date_range(2026) == "2024-11-02/2025-05-02"
+
+def test_past_year_no_month(mock_today):
+    assert create_date_range(2024) == "2024-06-30/2024-12-31"
+
+def test_past_year_with_month(mock_today):
+    assert create_date_range(2024, 10) == "2024-04-30/2024-10-31"
+
+def test_future_month_clamped_to_today(mock_today):
+    assert create_date_range(2025, 12) == "2024-11-02/2025-05-02"
+
+def test_same_month_as_today(mock_today):
+    assert create_date_range(2025, 5) == "2024-11-02/2025-05-02"
+
+def test_past_month_in_current_year(mock_today):
+    assert create_date_range(2025, 3) == "2024-09-30/2025-03-31"
+
+def test_past_month_in_current_year_with_duration(mock_today):
+    assert create_date_range(2025, 3, 3) == "2024-12-31/2025-03-31"


### PR DESCRIPTION
Previously,
- it used fixed date range from 1 Jan to 31 Dec.

Now
- `--month` option is added for assess command
- end date is current year and month if `--year` and `--month` are not set. If `--year` and `--month` are set, they are used as end year month. If end year month is future, it uses current year and month for end date
- it searches 6 months duration ending at end year month.
- added test cases for `create_date_range` function.
- mask nodata value for harmonization from subtracting 1000 for the new data
- mask nodata pixels after prediction since the model will create pixels with value = 1 (tree) for no data pixels.

Assess command is now like below

```diff
rapida assess
Usage: rapida assess [OPTIONS]

  Assess/evaluate a specific geospatial exposure components/variables

  `-a/--all` option to assess all components (it may take longer time).

  `-c/--component` to assess only specific components.

  `-v/--variable` to assess only specific variables. If a variable is
  specified, but it is not in specified components, the variable will be
  ignored.

  `-p/--project` to assess in a specific project folder other than current
  directory.

  As default, this command tries to avoid download/compute again if they
  already exist. If you wish to redownload or recompute by force, use
  `-f/--force` flag explicitly.

  Usage:

  rapida assess --all: assess all components

  rapida assess -c rwi: assess RWI component only.

  rapida assess -c rwi -c population: assess RWI and population component only

  rapida assess -c population -v male_total -v female_total: assess only male
  and female total population.

  rapida assess -c rwi -p ./data/sample_project: assess RWI component for
  RAPIDA project stored at sample_project folder.

Options:
  -a, --all                       compute all components and variables if this
                                  option is set
  -c, --components [deprivation|roads|buildings|landuse|rwi|elegrid|gdp|population]
                                  One or more components to be assessed. Valid
                                  input example: -c deprivation -c roads
  -v, --variables TEXT            The variable/s to be assessed. Will be
                                  filtered by selected components. Available
                                  variables per component:
                                  
                                  deprivation (depriv_max, depriv_mean,
                                  depriv_min)
                                  
                                  roads (roads_length, roads_count)
                                  
                                  buildings (buildings_area, nbuildings)
                                  
                                  landuse (crops_area, built_area)
                                  
                                  rwi (rwi_max, rwi_min, rwi_mean)
                                  
                                  elegrid (elegrid_length, elegrid_density)
                                  
                                  gdp (gdp_mean, gdp_sum, gdp_max, gdp_min)
                                  
                                  population (total, elderly_dependency,
                                  female_elderly, male_elderly, male_child,
                                  active_total, male_total, elderly_total,
                                  female_child, female_total, child_total,
                                  dependency, child_dependency, female_active,
                                  male_active)
  -y, --year INTEGER              The year for which to compute population and
                                  landuse  [default: 2025]
+  -m, --month INTEGER             Optional. The end month for which to compute
+                                  landuse.  If this is used together with
+                                  --year, it searches data until target year
+                                  and month for the last 6 months.  If this is
+                                  used without --year, and it is future month,
+                                  current month is used as end month.
  -p, --project DIRECTORY         Optional. A project folder with rapida.json
                                  can be specified. If not, current directory
                                  is considered as a project folder.
  -f, --force                     Force assess components. Downloaded data or
                                  computed data will be ignored and
                                  recomputed.
  --debug                         Set log level to debug
  -h, --help                      Show this message and exit.
```
