### PR TITLE
fix: fixed bug of predicted image is not shown in correct position

### DIFF
--- a/rapida/components/landuse/prediction.py
+++ b/rapida/components/landuse/prediction.py
@@ -194,8 +194,10 @@ def predict(img_paths: List[str], output_file_path: str, progress = None):
 
             for future in tasks:
                 row, col, original_tile = future.result()
-                dst.write(original_tile.astype(np.uint8), 1,
-                          window=Window(col, row, min(256, col_size - col), min(256, row_size - row)))
+                height, width = original_tile.shape
+                write_col = col + (buffer if col > 0 else 0)
+                write_row = row + (buffer if row > 0 else 0)
+                dst.write(original_tile.astype(np.uint8), 1, window=Window(write_col, write_row, width, height))
                 if predict_task is not None:
                     progress.update(predict_task, description=f"Predicted at row {row}, col {col}", advance=1)
 

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -264,8 +264,8 @@ async def download_from_https_async(
 
 
     finally:
-        # if os.path.exists(tmp_file):
-        #     os.remove(tmp_file)
+        if os.path.exists(tmp_file):
+            os.remove(tmp_file)
         if progress and download_task:
             progress.update(download_task, description=f"[blue] Downloaded file saved to {download_file}")
             progress.remove_task(download_task)


### PR DESCRIPTION
Previously, predicted image was shown in different place from actual position (255 pixels were shifted to top-left side). Now it shows in correct position as the below screenshot

<img width="1031" alt="image" src="https://github.com/user-attachments/assets/837cc8ed-d76f-4532-8566-6c3d4de7e55f" />
