### PR TITLE
fix: run prediction model concurrently with maximum workers from the number of CPU

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
     "requests-oauthlib",
     "fiona",
     "nest_asyncio",
-    "tensorflow"
+    "tensorflow",
+    "psutil"
 ]
 
 [project.optional-dependencies]

--- a/rapida/components/landuse/prediction.py
+++ b/rapida/components/landuse/prediction.py
@@ -1,6 +1,8 @@
 import concurrent
 import os
 import json
+import time
+
 import psutil
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
@@ -158,6 +160,7 @@ def hex_to_rgb(hex_color):
 
 
 def predict(img_paths: List[str], output_file_path: str, num_workers=None, progress = None):
+    t1 = time.time()
     predict_task = None
     if progress:
         predict_task = progress.add_task(f"[cyan]Starting land use prediction")
@@ -260,6 +263,9 @@ def predict(img_paths: List[str], output_file_path: str, num_workers=None, progr
                         raise
                     except StopIteration:
                         continue
+
+    t2 = time.time()
+    logger.debug(f"total time: {t2 - t1}")
 
     if predict_task is not None:
         progress.update(predict_task, description=f"[cyan]Prediction process completed successfully")

--- a/rapida/components/landuse/prediction.py
+++ b/rapida/components/landuse/prediction.py
@@ -166,7 +166,7 @@ def predict(img_paths: List[str], output_file_path: str, num_workers=None, progr
         predict_task = progress.add_task(f"[cyan]Starting land use prediction")
 
     col_size, row_size = preinference_check(img_paths)
-    tile_size=256
+    tile_size=1024
     buffer = 64
     landuse_nodata = 255
 
@@ -265,7 +265,7 @@ def predict(img_paths: List[str], output_file_path: str, num_workers=None, progr
                         continue
 
     t2 = time.time()
-    logger.debug(f"total time: {t2 - t1}")
+    logger.debug(f"total time of prediction: {t2 - t1}")
 
     if predict_task is not None:
         progress.update(predict_task, description=f"[cyan]Prediction process completed successfully")

--- a/rapida/components/landuse/prediction.py
+++ b/rapida/components/landuse/prediction.py
@@ -1,9 +1,12 @@
+import concurrent
 import os
 import json
+import psutil
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 
 from concurrent.futures import ProcessPoolExecutor
+import threading
 from typing import List
 import numpy as np
 import rasterio
@@ -99,15 +102,15 @@ def preinference_check(img_paths: List):
     return col_sizes[0], row_sizes[0]
 
 
-def process_tile(row, col, img_paths, buffer, row_size, col_size, landuse_nodata=255):
+def process_tile(row, col, img_paths, buffer, row_size, col_size, tile_size=256, landuse_nodata=255):
     logger.debug(f"Processing window at row {row}, col {col}")
 
     # create buffer (64px x 64px) for original tile size
     row_off = max(row - buffer, 0)
     col_off = max(col - buffer, 0)
 
-    window_height = min(row + 256 + buffer, row_size) - row_off
-    window_width = min(col + 256 + buffer, col_size) - col_off
+    window_height = min(row + tile_size + buffer, row_size) - row_off
+    window_width = min(col + tile_size + buffer, col_size) - col_off
 
     window = Window(col_off, row_off, window_width, window_height)
     raw_data = np.empty((window_height, window_width, 9), dtype="u2")
@@ -135,8 +138,8 @@ def process_tile(row, col, img_paths, buffer, row_size, col_size, landuse_nodata
     # crop original tile by removing buffer
     start_row = row - row_off
     start_col = col - col_off
-    end_row = start_row + min(256, row_size - row)
-    end_col = start_col + min(256, col_size - col)
+    end_row = start_row + min(tile_size, row_size - row)
+    end_col = start_col + min(tile_size, col_size - col)
 
     original_tile = lulc_prediction[start_row:end_row, start_col:end_col]
 
@@ -154,12 +157,13 @@ def hex_to_rgb(hex_color):
     return tuple(int(hex_color[i:i + 2], 16) for i in (0, 2, 4))
 
 
-def predict(img_paths: List[str], output_file_path: str, progress = None):
+def predict(img_paths: List[str], output_file_path: str, num_workers=None, progress = None):
     predict_task = None
     if progress:
         predict_task = progress.add_task(f"[cyan]Starting land use prediction")
 
     col_size, row_size = preinference_check(img_paths)
+    tile_size=256
     buffer = 64
     landuse_nodata = 255
 
@@ -197,23 +201,65 @@ def predict(img_paths: List[str], output_file_path: str, progress = None):
         unique_values_json = json.dumps(statistics_unique_values, ensure_ascii=False)
         dst.update_tags(1, STATISTICS_UNIQUE_VALUES=unique_values_json)
 
-        tasks = []
-        with ProcessPoolExecutor() as executor:
-            tile_size = 256
-            for row in range(0, row_size, tile_size):
-                for col in range(0, col_size, tile_size):
-                    tasks.append(
-                        executor.submit(process_tile, row, col, img_paths, buffer, row_size, col_size, landuse_nodata))
+        tile_jobs = [
+            (row, col)
+            for row in range(0, row_size, tile_size)
+            for col in range(0, col_size, tile_size)
+        ]
 
-            if predict_task is not None:
-                progress.update(predict_task, description=f"[red]Predicting land use", total=len(tasks))
+        if predict_task:
+            progress.update(predict_task, description=f"[cyan]Running prediction for {len(tile_jobs)} tiles", total=len(tile_jobs))
 
-            for future in tasks:
-                row, col, original_tile = future.result()
-                dst.write(original_tile.astype(np.uint8), 1,
-                          window=Window(col, row, min(256, col_size - col), min(256, row_size - row)))
-                if predict_task is not None:
-                    progress.update(predict_task, description=f"Predicted at row {row}, col {col}", advance=1)
+        write_lock = threading.Lock()
+
+        if num_workers is None:
+            num_workers = psutil.cpu_count(logical=False)
+
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            job_iter = iter(tile_jobs)
+            running_futures = {}
+
+            # add first batch to process
+            for _ in range(num_workers):
+                row, col = next(job_iter)
+                task_id = progress.add_task(f"[green]Processing tile ({row}, {col})", total=None) if progress else None
+                fut = executor.submit(process_tile, row, col, img_paths,
+                                      buffer, row_size, col_size,
+                                      tile_size, landuse_nodata)
+                running_futures[fut] = (row, col, task_id)
+
+            while running_futures:
+                # wait for any future to complete
+                done, _ = concurrent.futures.wait(running_futures, return_when=concurrent.futures.FIRST_COMPLETED)
+
+                for fut in done:
+                    row, col, task_id = running_futures.pop(fut)
+                    row, col, original_tile = fut.result()
+
+                    with write_lock:
+                        dst.write(original_tile.astype(np.uint8), 1,
+                                  window=Window(col, row, min(tile_size, col_size - col), min(tile_size, row_size - row)))
+
+                    if progress:
+                        if predict_task:
+                            progress.update(predict_task, advance=1)
+                        if task_id:
+                            progress.remove_task(task_id)
+
+                    # add next job
+                    try:
+                        row, col = next(job_iter)
+                        task_id = progress.add_task(f"[green]Processing tile ({row}, {col})", total=None) if progress else None
+                        fut = executor.submit(process_tile, row, col, img_paths,
+                                              buffer, row_size, col_size,
+                                              tile_size, landuse_nodata)
+                        running_futures[fut] = (row, col, task_id)
+                    except KeyboardInterrupt:
+                        logger.info("Prediction interrupted by user. Cancelling tasks..")
+                        executor.shutdown(wait=True, cancel_futures=True)
+                        raise
+                    except StopIteration:
+                        continue
 
     if predict_task is not None:
         progress.update(predict_task, description=f"[cyan]Prediction process completed successfully")


### PR DESCRIPTION
closes #384

- added psutil to check the number of available CPUs
- run model concurrently. If 2 CPU is available, 2 workers will be running model.
- It shows progress task for each workers

<img width="813" alt="image" src="https://github.com/user-attachments/assets/8e2c36f6-dedb-42f3-ac2e-0d1c3e2a39ef" />


just memo for my experiment
- current version
  - tilesize: 256
    - ProcessPoolExecutor: 432.8232669830322
- after applying changes of PR
  - tilesize: 256
    - ProcessPoolExecutor: 432.8232669830322 
    - ThreadPoolExecutor: n/a
  - tilesize: 512
    - ProcessPoolExecutor: 236.56645345687866 seconds
    - ThreadPoolExecutor: 295.22949504852295 seconds
  - tilesize: 1024
    - ProcessPoolExecutor: 172.0952889919281
    - ThreadPoolExecutor: n/a
