### PR TITLE
fix: improve the performance of download 

### DIFF
--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -106,7 +106,7 @@ class LanduseVariable(Variable):
         project = Project(os.getcwd())
         output_dir = os.path.join(os.path.dirname(project.geopackage_file_path), self.component)
         assets = list(self.target_asset.values())
-        return [os.path.join(output_dir, f"{asset}.tif") for asset in assets]
+        return [os.path.join(output_dir, f"{asset}.vrt") for asset in assets]
 
     @property
     def prediction_output_image(self) -> str:

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import re
-import tempfile
 from glob import glob
 from collections import defaultdict
 import concurrent.futures
@@ -15,7 +14,6 @@ from datetime import datetime, date
 from rich.progress import Progress
 import pystac_client
 import rasterio
-from rasterio.crs import CRS
 import httpx
 import geopandas as gpd
 import numpy as np

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -271,7 +271,7 @@ async def download_from_https_async(
                             raise e
                     except Exception as e:
                         logger.error(f"Download failed for {start}:{end}: {e}")
-                        break
+                        raise e
 
             tasks = [fetch_range(start, end, url, semaphore) for start, end in ranges]
 

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import math
 import os
 import re
 from glob import glob

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -599,7 +599,7 @@ async def download_stac(
         progress.update(stac_task, description=f"[cyan]Preparing to download {len(asset_urls)} assets", total=len(asset_urls))
 
     t2 = time.time()
-    logger.info(f"STAC Item search: {t2 - t1} seconds")
+    logger.debug(f"STAC Item search: {t2 - t1} seconds")
 
     asset_nodata = {}
 
@@ -682,7 +682,7 @@ async def download_stac(
         progress.remove_task(stac_task)
 
     t4 = time.time()
-    logger.info(f"Download completed: {t4 - t1} seconds")
+    logger.debug(f"Download completed: {t4 - t1} seconds")
 
     return output_files
 

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 from glob import glob
@@ -214,78 +215,19 @@ async def download_from_https_async(
 
         cutoff = datetime(2022, 1, 25)
 
-        if progress is not None and download_task is not None:
-            progress.update(download_task, total=remote_content_length)
+        async with httpx.AsyncClient() as client:
+            async with client.stream("GET", file_url) as response:
+                response.raise_for_status()
+                total = int(response.headers.get("content-length", 0))
 
-        async def download_file_in_parallel(url, file_path, total_size, chunk_count=10, max_concurrent=5):
-            """
-            download file in parallel with the number of chunk count given
+                if progress is not None and download_task is not None:
+                    progress.update(download_task, total=total)
 
-            :param url: URL to download
-            :param file_path: file path to write
-            :param total_size: total size of file
-            :param chunk_count: Number of chunks to split download into
-            :param max_concurrent: Maximum number of concurrent HTTP requests
-            :return: downloaded file path
-            """
-            chunk_size = total_size // chunk_count
-            ranges = [
-                (i * chunk_size, total_size - 1 if i == chunk_count - 1 else (i + 1) * chunk_size - 1)
-                for i in range(chunk_count)
-            ]
-
-            with open(file_path, "wb") as f:
-                f.truncate(total_size)
-
-            semaphore = asyncio.Semaphore(max_concurrent)
-
-            async def fetch_range(start, end, data_url, semaphore, max_retries=3, retry_delay=2):
-                """
-                Fetch a byte range with retry support.
-
-                :param start: Byte range start
-                :param end: Byte range end
-                :param data_url: URL to fetch from
-                :param semaphore: asyncio.Semaphore instance for concurrency limiting
-                :param max_retries: Max retry attempts
-                :param retry_delay: Initial delay between retries (seconds)
-                :return: (start_offset, content_bytes)
-                """
-                attempt = 0
-                headers = {"Range": f"bytes={start}-{end}"}
-
-                while attempt < max_retries:
-                    try:
-                        async with semaphore:
-                            async with httpx.AsyncClient() as client:
-                                response = await client.get(data_url, headers=headers)
-                                response.raise_for_status()
-                                return start, response.content
-                    except asyncio.CancelledError:
-                        raise
-                    except (httpx.RequestError, httpx.TimeoutException) as e:
-                        attempt += 1
-                        if attempt < max_retries:
-                            await asyncio.sleep(retry_delay * attempt)
-                        else:
-                            raise e
-                    except Exception as e:
-                        logger.error(f"Download failed for {start}:{end}: {e}")
-                        raise e
-
-            tasks = [fetch_range(start, end, url, semaphore) for start, end in ranges]
-
-            for task in asyncio.as_completed(tasks):
-                start, content = await task
-                with open(file_path, "r+b") as f:
-                    f.seek(start)
-                    f.write(content)
-                if progress and download_task:
-                    progress.update(download_task, advance=len(content))
-
-            return file_path
-
-        await download_file_in_parallel(file_url, tmp_file, remote_content_length)
+                with open(tmp_file, "wb") as f:
+                    async for chunk in response.aiter_bytes():
+                        f.write(chunk)
+                        if progress is not None and download_task is not None:
+                            progress.update(download_task, advance=len(chunk))
 
         if progress and download_task:
             progress.update(download_task, description=f"[blue] Reprojecting...")

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -9,21 +9,17 @@ import concurrent.futures
 import threading
 from typing import Optional
 from calendar import monthrange
-
 from osgeo import gdal
 from datetime import datetime, date
 from rich.progress import Progress
 import pystac_client
 import rasterio
-from rasterio.warp import reproject, Resampling, calculate_default_transform
 from rasterio.crs import CRS
 import httpx
 import geopandas as gpd
 import numpy as np
 import shapely
-from shapely.ops import voronoi_diagram
 from shapely.geometry import Point, MultiPoint, Polygon
-from rapida.util import geo
 import time
 
 
@@ -159,11 +155,26 @@ async def download_from_https_async(
         file_url: str,
         target: str,
         target_srs: str,
+        geopackage_file_path,
+        polygons_layer_name,
         no_data_value: int = 0,
         item_datetime: str = None,
         cloud_cover: float = None,
         progress=None,
 ) -> str:
+    """
+    Download JP2 file from STAC server, then reproject and crop by project area, and transform to GeoTiff file.
+
+    :param file_url: file URL to download
+    :param target: target file name without extension
+    :param geopackage_file_path: path to geopackage file
+    :param polygons_layer_name: name of layer polygon layer in geopackage to mask
+    :param no_data_value: nodata value. default is 0
+    :param item_datetime: item datetime string
+    :param cloud_cover: cloud cover percentage
+    :param progress: rich progress instance
+    :return: output file URL
+    """
     download_task = None
     if progress is not None:
         download_task = progress.add_task(
@@ -288,41 +299,38 @@ async def download_from_https_async(
             if acquisition_date >= cutoff:
                 data = harmonize_to_old(data, nodata)  # Ensure harmonize_to_old is defined
 
-            transform, width, height = calculate_default_transform(
-                src.crs, dst_crs, src.width, src.height, *src.bounds
+            profile = src.profile
+            profile.update(driver="GTiff", dtype=data.dtype, count=src.count)
+
+            vsimem_path = "/vsimem/in.tif"
+            with rasterio.MemoryFile() as memfile:
+                with memfile.open(**profile) as dataset:
+                    dataset.write(data)
+                gdal.FileFromMemBuffer(vsimem_path, memfile.read())
+
+            warp_options = gdal.WarpOptions(
+                dstSRS=target_srs.ExportToWkt(),
+                format="GTiff",
+                creationOptions=["COMPRESS=ZSTD", "TILED=YES"],
+                srcNodata=nodata,
+                dstNodata=nodata,
+                resampleAlg="near",
+                cutlineDSName=geopackage_file_path,
+                cutlineLayer=polygons_layer_name,
+                cropToCutline=True,
             )
 
-            profile = src.profile.copy()
-            profile.update({
-                "crs": dst_crs,
-                "transform": transform,
-                "width": width,
-                "height": height,
-                "driver": "GTiff",
-                "compress": "ZSTD",
-                "tiled": True,
-                "nodata": nodata,
-            })
-
-            with rasterio.open(download_file, "w", **profile) as dst:
-                dst.update_tags(JP2_CONTENT_LENGTH=str(remote_content_length))
-                if item_datetime:
-                    dst.update_tags(ITEM_DATETIME=item_datetime)
-                if cloud_cover:
-                    dst.update_tags(CLOUD_COVER=cloud_cover)
-                for i in range(1, src.count + 1):
-                    reproject(
-                        source=data[i - 1],
-                        destination=rasterio.band(dst, i),
-                        src_transform=src.transform,
-                        src_crs=src.crs,
-                        dst_transform=transform,
-                        dst_crs=dst_crs,
-                        resampling=Resampling.nearest,
-                        src_nodata=nodata,
-                        dst_nodata=nodata,
-                    )
-
+            rds = gdal.Warp(destNameOrDestDS=download_file,
+                      srcDSOrSrcDSTab=vsimem_path,
+                      options=warp_options)
+            metadata = {"JP2_CONTENT_LENGTH": str(remote_content_length)}
+            if item_datetime is not None:
+                metadata["ITEM_DATETIME"] = item_datetime
+            if cloud_cover is not None:
+                metadata["CLOUD_COVER"] = str(cloud_cover)
+            rds.SetMetadata(metadata)
+            gdal.Unlink(vsimem_path)
+            rds = None
 
     finally:
         if os.path.exists(tmp_file):
@@ -359,8 +367,6 @@ def get_bounds_and_resolution(file_paths):
 
 def crop_asset_files(base_dir,
                      target_srs,
-                     geopackage_file_path,
-                     polygons_layer_name,
                      asset_nodata: dict[str, int],
                      progress: Progress = None,):
     """
@@ -369,8 +375,6 @@ def crop_asset_files(base_dir,
 
     :param base_dir: Root directory for downloaded sentinel data
     :param target_srs: target projection CRS
-    :param geopackage_file_path: path to geopackage file
-    :param polygons_layer_name: name of layer polygon layer in geopackage to mask
     :param progress: rich progress object
     """
     post_task = None
@@ -409,7 +413,6 @@ def crop_asset_files(base_dir,
         if progress is not None and post_task is not None:
             progress.update(post_task, description="[red] Creating VRT...")
         vrt_path = os.path.join(base_dir, f"{band_name}.vrt")
-        masked_path = os.path.join(base_dir, f"{band_name}.tif")
 
         # get maximum bounds from all files
         bounds = get_bounds_and_resolution(files)[0]
@@ -432,20 +435,7 @@ def crop_asset_files(base_dir,
         if progress is not None and post_task is not None:
             progress.update(post_task, description="[red] Cropping VRT...")
 
-        # crop VRT by project area to GeoTiff
-        geo.import_raster(
-            source=vrt_path, dst=masked_path, target_srs=target_srs,
-            x_res=xRes, y_res=yRes,
-            crop_ds=geopackage_file_path, crop_layer_name=polygons_layer_name,
-            return_handle=False,
-            progress=progress,
-            warpMemoryLimit=1024,
-        )
-
-        if os.path.exists(vrt_path):
-            os.remove(vrt_path)
-
-        output_files.append(masked_path)
+        output_files.append(vrt_path)
 
         if progress is not None and post_task is not None:
             progress.update(post_task, description=f"[red] Processed {band_name}", advance=1)
@@ -668,7 +658,7 @@ async def download_stac(
         progress.update(stac_task, description=f"[cyan]Preparing to download {len(asset_urls)} assets", total=len(asset_urls))
 
     t2 = time.time()
-    logger.debug(f"STAC Item search: {t2 - t1} seconds")
+    logger.info(f"STAC Item search: {t2 - t1} seconds")
 
     asset_nodata = {}
 
@@ -697,6 +687,8 @@ async def download_stac(
                         no_data_value=nodata,
                         item_datetime=target_datetime,
                         cloud_cover=cloud_cover,
+                        geopackage_file_path=geopackage_file_path,
+                        polygons_layer_name=polygons_layer_name,
                     )
                     if progress and stac_task:
                         progress.update(stac_task, description=f"[green]Saved {tile_id}:{band_name}", advance=1)
@@ -740,8 +732,6 @@ async def download_stac(
     output_files = crop_asset_files(
         base_dir=output_dir,
         target_srs=target_srs,
-        geopackage_file_path=geopackage_file_path,
-        polygons_layer_name=polygons_layer_name,
         asset_nodata=asset_nodata,
         progress=progress,
     )
@@ -751,7 +741,7 @@ async def download_stac(
         progress.remove_task(stac_task)
 
     t4 = time.time()
-    logger.debug(f"Download completed: {t4 - t1} seconds")
+    logger.info(f"Download completed: {t4 - t1} seconds")
 
     return output_files
 


### PR DESCRIPTION
I updated download_from_https_async function logic of downloading a file

## first improvement

previously, it downloads file by 8192 chunk size, this becomes too many chunks and it takes a bit longer time to request HTTP everytime.

New approarch is to divide file to 10 chunks, and it downloads chunks with max 5 workers concurrently.

I tested in small area of Kigali

- before changing

```
[05/07/25 08:02:22] INFO     STAC Item search: 3.04833722114563 seconds                                                                                                    stac.py:613
[05/07/25 08:05:53] INFO     STAC Item download: 210.75929975509644 seconds                                                                                                stac.py:677
[05/07/25 08:05:55] INFO     Download completed: 216.37378478050232 seconds   
```

- after changing

```
[05/07/25 09:29:11] INFO     STAC Item search: 4.000098705291748 seconds                                                                                                   stac.py:669
[05/07/25 09:32:02] INFO     STAC Item download: 170.78534173965454 seconds                                                                                                stac.py:733
[05/07/25 09:32:05] INFO     Download completed: 177.44660878181458 seconds 
```

it improves 22% faster now.

## second improvement

- after switching to gdal.warp for reprojecting

```
[05/07/25 11:18:11] INFO     STAC Item search: 3.2910964488983154 seconds                                                                                                    stac.py:739
[05/07/25 11:20:56] INFO     Download completed: 168.94079303741455 seconds  
```

- crop downloaded item by gdal.warp in tile level, and use VRT directly for prediction

```
[05/07/25 11:29:45] INFO     STAC Item search: 4.108993053436279 seconds                                                                                                   stac.py:670
[05/07/25 11:31:58] INFO     Download completed: 136.66442918777466 seconds  
```

Now approximately 58% becomes faster than current version

## Last version

I realized the current version of using https streaming is not bad. but setting chunk_size is not such effective according to the below stackoverflow. and the response time is not such different with/without chunk_size.

https://stackoverflow.com/questions/70102869/python-httpx-stream-data-asynchronously

```
[05/07/25 13:26:06] INFO     STAC Item search: 4.307923078536987 seconds                                                                                                   stac.py:606
[05/07/25 13:29:01] INFO     Download completed: 179.1740288734436 seconds   
```

This approarch is a bit slower than second version, but the code is simpler. so I prefer using this version for ease of maintenance