### PR TITLE
fix: restructure landuse component logic

### DIFF
--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -10,7 +10,7 @@ import geopandas as gpd
 
 from rapida.components.landuse.stac import interpolate_stac_source, download_stac
 from rapida.components.landuse.prediction import predict
-from rapida.components.landuse.constants import STAC_MAP
+from rapida.components.landuse.constants import STAC_MAP, SENTINEL2_ASSET_MAP
 from rapida.constants import GTIFF_CREATION_OPTIONS, POLYGONS_LAYER_NAME
 from rapida.core.component import Component
 from rapida.core.variable import Variable
@@ -90,13 +90,7 @@ class LanduseVariable(Variable):
         """
         Dictionary of Earth search asset name and band name
         """
-        needed_assets = (
-            'B02', 'B03', 'B04', 'B05', 'B06', 'B07', 'B08', 'B11', 'B12')
-        earth_search_assets = (
-            'blue', 'green', 'red', 'rededge1', 'rededge2', 'rededge3', 'nir', 'swir16', 'swir22'
-        )
-        asset_map = dict(zip(earth_search_assets, needed_assets))
-        return asset_map
+        return SENTINEL2_ASSET_MAP
 
     @property
     def downloaded_files(self) -> List[str]:

--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -9,7 +9,7 @@ from rich.progress import Progress
 import geopandas as gpd
 
 from rapida.components.landuse.stac import interpolate_stac_source, download_stac
-from rapida.components.landuse.prediction import predict
+# from rapida.components.landuse.prediction import predict
 from rapida.components.landuse.constants import STAC_MAP, SENTINEL2_ASSET_MAP
 from rapida.constants import GTIFF_CREATION_OPTIONS, POLYGONS_LAYER_NAME
 from rapida.core.component import Component
@@ -92,15 +92,6 @@ class LanduseVariable(Variable):
         """
         return SENTINEL2_ASSET_MAP
 
-    @property
-    def downloaded_files(self) -> List[str]:
-        """
-        The list of downloaded files for this component
-        """
-        project = Project(os.getcwd())
-        output_dir = os.path.join(os.path.dirname(project.geopackage_file_path), self.component)
-        assets = list(self.target_asset.values())
-        return [os.path.join(output_dir, f"{asset}.vrt") for asset in assets]
 
     @property
     def prediction_output_image(self) -> str:
@@ -109,7 +100,7 @@ class LanduseVariable(Variable):
         """
         project = Project(os.getcwd())
         output_dir = os.path.join(os.path.dirname(project.geopackage_file_path), self.component)
-        return os.path.join(output_dir, f"{self.component}_prediction.tif")
+        return os.path.join(output_dir, f"{self.component}_prediction.vrt")
 
 
     def __init__(self, **kwargs):
@@ -143,22 +134,12 @@ class LanduseVariable(Variable):
         project = Project(os.getcwd())
         progress: Progress = kwargs.get('progress', None)
 
-        output_dir = os.path.join(os.path.dirname(project.geopackage_file_path), self.component)
-
-        asset_files = self.downloaded_files
-        exists = 0
-        for asset in asset_files:
-            if os.path.exists(asset):
-                exists += 1
-        if force == False and exists == len(asset_files):
-            # if all files already exist, skip download
-            pass
-        else:
+        if force or not os.path.exists(self.prediction_output_image):
             asyncio.run(download_stac(stac_url=self.stac_url,
                           collection_id=self.collection_id,
                           geopackage_file_path=project.geopackage_file_path,
                           polygons_layer_name=project.polygons_layer_name,
-                          output_dir=output_dir,
+                          output_file=self.prediction_output_image,
                           target_year=self.target_year,
                           target_month=self.target_month,
                           target_assets=self.target_asset,
@@ -234,16 +215,10 @@ class LanduseVariable(Variable):
 
 
     def compute(self, **kwargs):
-        force = kwargs.get('force', False)
         progress = kwargs.get('progress', None)
-
-        # run the prediction only when the force or prediction image doesn't exist
-        if force or not os.path.exists(self.prediction_output_image):
-            predict(
-                img_paths=self.downloaded_files,
-                output_file_path=self.prediction_output_image,
-                progress=progress,
-            )
+        variable_task = None
+        if progress:
+            variable_task = progress.add_task(f"[green]Masking computing land use for variable {self.name}", total=100)
 
         source_value = self.target_band_value
 
@@ -254,9 +229,6 @@ class LanduseVariable(Variable):
             "BLOCKXSIZE": "256",
             "BLOCKYSIZE": "256"
         }
-
-        if progress:
-            variable_task = progress.add_task(f"[green]Masking computing land use for variable {self.name}", total=100)
 
         def progress_callback(complete, message, user_data):
             if progress and variable_task is not None:

--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -8,8 +8,7 @@ from osgeo_utils.gdal_calc import Calc
 from rich.progress import Progress
 import geopandas as gpd
 
-from rapida.components.landuse.stac import interpolate_stac_source, download_stac
-# from rapida.components.landuse.prediction import predict
+from rapida.components.landuse.stac import download_stac
 from rapida.components.landuse.constants import STAC_MAP, SENTINEL2_ASSET_MAP
 from rapida.constants import GTIFF_CREATION_OPTIONS, POLYGONS_LAYER_NAME
 from rapida.core.component import Component
@@ -57,7 +56,7 @@ class LanduseVariable(Variable):
         """
         STAC Server root URL
         """
-        stac_id = interpolate_stac_source(self.source)['id']
+        stac_id = self._interpolate_stac_source(self.source)['id']
         url = STAC_MAP[stac_id]
         assert url is not None, f'Unsupported stac_id {stac_id}'
         return url
@@ -67,7 +66,7 @@ class LanduseVariable(Variable):
         """
         STAC Collection ID
         """
-        collection = interpolate_stac_source(self.source)['collection']
+        collection = self._interpolate_stac_source(self.source)['collection']
         return collection
 
     @property
@@ -82,7 +81,7 @@ class LanduseVariable(Variable):
         """
         Target band value for zonal statistics
         """
-        value = interpolate_stac_source(self.source)['value']
+        value = self._interpolate_stac_source(self.source)['value']
         return int(value)
 
     @property
@@ -320,3 +319,20 @@ class LanduseVariable(Variable):
     def resolve(self, **kwargs):
         pass
 
+    def _interpolate_stac_source(self, source: str) -> dict[str, str]:
+        """
+        Interpolate stac source. Source of stac should be defined like below:
+
+        {stac_id}:{collection_id}:{target band value}
+
+        :param source: stac source
+        :return: dist consist of id, collection and value
+        """
+        parts = source.split(':')
+        assert len(parts) == 3, 'Invalid source definition'
+        stac_id, collection, target_value = parts
+        return {
+            'id': stac_id,
+            'collection': collection,
+            'value': target_value
+        }

--- a/rapida/components/landuse/constants.py
+++ b/rapida/components/landuse/constants.py
@@ -13,3 +13,11 @@ DYNAMIC_WORLD_COLORMAP = {
 STAC_MAP = {
     'earth-search': 'https://earth-search.aws.element84.com/v1'
 }
+
+needed_assets = (
+    'B02', 'B03', 'B04', 'B05', 'B06', 'B07', 'B08', 'B11', 'B12'
+)
+earth_search_assets = (
+    'blue', 'green', 'red', 'rededge1', 'rededge2', 'rededge3', 'nir', 'swir16', 'swir22'
+)
+SENTINEL2_ASSET_MAP = dict(zip(earth_search_assets, needed_assets))

--- a/rapida/components/landuse/sentinel_item.py
+++ b/rapida/components/landuse/sentinel_item.py
@@ -28,14 +28,25 @@ class SentinelItem(object):
 
     @property
     def item(self)->pystac.Item:
+        """
+        Get STAC Item instance
+        :return: pystac.Item instance
+        """
         return self._item
 
     @item.setter
     def item(self, item:pystac.Item):
+        """
+        Set STAC Item instance
+        :param item: pystac.Item
+        """
         self._item = item
 
     @property
     def id(self)->str:
+        """
+        ID for the class instance. It uses grid:code for unique ID.
+        """
         tile_id = self._item.properties.get("grid:code")
         if tile_id is None:
             tile_id = self._item.id
@@ -50,6 +61,9 @@ class SentinelItem(object):
 
     @property
     def target_srs(self) -> osr.SpatialReference:
+        """
+        Get target spatial reference used in the mask layer
+        """
         if self._target_srs is None:
             ds = ogr.Open(self.mask_file)
             if ds is None:
@@ -65,6 +79,9 @@ class SentinelItem(object):
 
     @property
     def min_resolution(self) -> int:
+        """
+        Get minimum resolution of assets from item JSON object
+        """
         resolutions = []
         for asset_key in self.target_asset:
             asset = self.item.assets[asset_key]
@@ -79,6 +96,9 @@ class SentinelItem(object):
 
     @property
     def asset_nodata(self) -> dict[str, int]:
+        """
+        Get no data value for asset from item JSON object
+        """
         nodata_dict = {}
         for asset_key, band_name in self.target_asset.items():
             asset = self.item.assets.get(asset_key)
@@ -96,6 +116,9 @@ class SentinelItem(object):
 
     @property
     def asset_files(self) -> dict[str, str]:
+        """
+        The dictionary of file paths to assets. If download_assets function is not called, it returns empty dict.
+        """
         if len(self._asset_files) == 0:
             return {}
         sorted_dict = dict(sorted(self._asset_files.items(), key=lambda x: int(x[0][1:])))
@@ -104,6 +127,9 @@ class SentinelItem(object):
 
     @property
     def predicted_file(self)->str:
+        """
+        Get the file path of the predicted file. If download_assets function is not called, it returns empty string.
+        """
         if len(self.asset_files) == 0:
             return ""
         predict_file = os.path.join(os.path.dirname(list(self.asset_files.values())[0]), "landuse_prediction.tif")

--- a/rapida/components/landuse/sentinel_item.py
+++ b/rapida/components/landuse/sentinel_item.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import asyncio
@@ -140,6 +141,10 @@ class SentinelItem(object):
         :param max_workers: maximum number of parallel downloads
         :return: Dictionary of band name -> downloaded file path
         """
+        item_path = os.path.join(download_dir, self.id, "item.json")
+        with open(item_path, "w", encoding="utf-8") as f:
+            json.dump(self.item.to_dict(), f, indent=2)
+
         self._asset_files = {}
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -348,7 +353,6 @@ class SentinelItem(object):
                                 srcDSOrSrcDSTab=vsimem_path,
                                 options=warp_options)
                 metadata = {"JP2_CONTENT_LENGTH": str(remote_content_length)}
-
                 item_datetime = self.item.datetime.isoformat() if self.item.datetime else None
                 if item_datetime is not None:
                     metadata["ITEM_DATETIME"] = item_datetime

--- a/rapida/components/landuse/sentinel_item.py
+++ b/rapida/components/landuse/sentinel_item.py
@@ -202,7 +202,7 @@ class SentinelItem(object):
         predict(
             img_paths=img_paths,
             output_file_path=self.predicted_file,
-            num_workers=1,
+            # num_workers=1,
             progress=progress,
         )
         return self.predicted_file
@@ -309,7 +309,7 @@ class SentinelItem(object):
                                 progress.update(download_task, advance=len(chunk))
 
             if progress and download_task:
-                progress.update(download_task, description=f"[blue] Reprojecting...")
+                progress.update(download_task, description=f"[blue] Reprojecting {jp2_file}...")
 
             with rasterio.open(jp2_file) as src:
                 data = src.read()

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -1,9 +1,8 @@
-import asyncio
 import json
 import logging
 import os
 import concurrent.futures
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 import threading
 from queue import Queue
 from typing import Optional
@@ -12,7 +11,6 @@ from osgeo import gdal
 from datetime import date
 from rich.progress import Progress
 import pystac_client
-import rasterio
 import geopandas as gpd
 import numpy as np
 import shapely
@@ -108,29 +106,6 @@ def create_date_range(target_year: int, target_month: Optional[int] = None, dura
     start_date = subtract_months(end_date, duration)
 
     return f"{start_date.strftime('%Y-%m-%d')}/{end_date.strftime('%Y-%m-%d')}"
-
-
-def get_bounds_and_resolution(file_paths):
-    bounds = []
-    xres_list = []
-    yres_list = []
-
-    for fp in file_paths:
-        with rasterio.open(fp) as src:
-            bounds.append(src.bounds)
-            xres, yres = src.res
-            xres_list.append(xres)
-            yres_list.append(yres)
-
-    left = min(b.left for b in bounds)
-    bottom = min(b.bottom for b in bounds)
-    right = max(b.right for b in bounds)
-    top = max(b.top for b in bounds)
-
-    xRes = min(xres_list)
-    yRes = min(yres_list)
-
-    return (left, bottom, right, top), xRes, yRes
 
 
 def merge_or_voronoi(df: gpd.GeoDataFrame, scene_size=110000) -> list[Polygon]:

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -322,7 +322,7 @@ async def download_stac(
         progress.update(stac_task, description=f"[cyan]Preparing to download {len(sentinel_items)} items", total=len(sentinel_items))
 
     t2 = time.time()
-    logger.info(f"STAC Item search: {t2 - t1} seconds")
+    logger.debug(f"STAC Item search: {t2 - t1} seconds")
 
     output_dir = os.path.dirname(output_file)
     os.makedirs(output_dir, exist_ok=True)
@@ -379,7 +379,7 @@ async def download_stac(
         os.remove(tmp_cutline_path)
 
     t3 = time.time()
-    logger.info(f"STAC Items processed: {t3 - t2} seconds")
+    logger.debug(f"STAC Items processed: {t3 - t2} seconds")
 
     if progress and stac_task:
         progress.update(stac_task, description="[green]Creating mosaic...")
@@ -412,7 +412,7 @@ async def download_stac(
         progress.remove_task(stac_task)
 
     t4 = time.time()
-    logger.info(f"Download completed: {t4 - t1} seconds")
+    logger.debug(f"Download completed: {t4 - t1} seconds")
 
     return output_file
 

--- a/rapida/components/landuse/stac.py
+++ b/rapida/components/landuse/stac.py
@@ -22,25 +22,6 @@ from rapida.components.landuse.sentinel_item import SentinelItem
 logger = logging.getLogger('rapida')
 
 
-def interpolate_stac_source(source: str) -> dict[str, str]:
-    """
-    Interpolate stac source. Source of stac should be defined like below:
-
-    {stac_id}:{collection_id}:{target band value}
-
-    :param source: stac source
-    :return: dist consist of id, collection and value
-    """
-    parts = source.split(':')
-    assert len(parts) == 3, 'Invalid source definition'
-    stac_id, collection, target_value = parts
-    return {
-        'id': stac_id,
-        'collection': collection,
-        'value': target_value
-    }
-
-
 def create_date_range(target_year: int, target_month: Optional[int] = None, duration: int = 6) -> str:
     """
     Generate a date range string in the format 'YYYY-MM-DD/YYYY-MM-DD'.


### PR DESCRIPTION
- created `SentinelItem` class to manage download and prediction per a STAC Item
- previously, it creates a VRT for each band, then run prediction for mosaic. Now prediction is done at each stac item level
- after download part is done, create a VRT for predicted land use image
- sort predicted image by datetime and cloud cover rate before creating mosaic (VRT)

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/13fd91bd-3e4c-462c-9c60-6bb203db42a6" />
