### PR TITLE
feat: delete cloud from land use image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,9 @@ dependencies = [
     "requests-oauthlib",
     "fiona",
     "nest_asyncio",
-    "tensorflow==2.16.1",
-    "psutil"
+    "tensorflow==2.16.2",
+    "psutil",
+    "s2cloudless"
 ]
 
 [project.optional-dependencies]

--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -9,7 +9,7 @@ from rich.progress import Progress
 import geopandas as gpd
 
 from rapida.components.landuse.download import download_stac
-from rapida.components.landuse.constants import STAC_MAP, SENTINEL2_ASSET_MAP
+from rapida.components.landuse.constants import STAC_MAP
 from rapida.constants import GTIFF_CREATION_OPTIONS, POLYGONS_LAYER_NAME
 from rapida.core.component import Component
 from rapida.core.variable import Variable
@@ -84,13 +84,6 @@ class LanduseVariable(Variable):
         value = self._interpolate_stac_source(self.source)['value']
         return int(value)
 
-    @property
-    def target_asset(self) -> dict[str, str]:
-        """
-        Dictionary of Earth search asset name and band name
-        """
-        return SENTINEL2_ASSET_MAP
-
 
     @property
     def prediction_output_image(self) -> str:
@@ -141,7 +134,6 @@ class LanduseVariable(Variable):
                           output_file=self.prediction_output_image,
                           target_year=self.target_year,
                           target_month=self.target_month,
-                          target_assets=self.target_asset,
                           target_srs=project.target_srs,
                           progress=progress))
 

--- a/rapida/components/landuse/cloud.py
+++ b/rapida/components/landuse/cloud.py
@@ -1,0 +1,194 @@
+import concurrent
+import os
+import time
+import psutil
+from concurrent.futures import ProcessPoolExecutor
+import threading
+from typing import List
+import numpy as np
+import rasterio
+from rasterio.windows import Window
+from s2cloudless import S2PixelCloudDetector, download_bands_and_valid_data_mask
+from rich.progress import Progress
+from rapida.util.setup_logger import setup_logger
+
+
+logger = setup_logger('rapida')
+
+
+def preinference_check(img_paths: List):
+    assert len(img_paths) > 0 and len(img_paths) == 10, "10 bands are required for cloud detection"
+    col_sizes = []
+    row_sizes = []
+    for img_path in img_paths:
+        if not os.path.exists(img_path):
+            raise FileNotFoundError(f"File {img_path} does not exist")
+        with rasterio.open(img_path) as src:
+            if src.count != 1:
+                raise ValueError("Each of the image must have one band")
+            col_sizes.append(src.width)
+            row_sizes.append(src.height)
+    if len(set(col_sizes)) != 1:
+        raise ValueError("All images must have the same dimensions")
+    if len(set(row_sizes)) != 1:
+        raise ValueError("All images must have the same dimensions")
+    return col_sizes[0], row_sizes[0]
+
+
+def process_tile(row, col, img_paths, buffer, row_size, col_size, tile_size=256, scale=0.0001):
+    logger.debug(f"Processing window at row {row}, col {col}")
+
+    # create buffer (64px x 64px) for original tile size
+    row_off = max(row - buffer, 0)
+    col_off = max(col - buffer, 0)
+
+    window_height = min(row + tile_size + buffer, row_size) - row_off
+    window_width = min(col + tile_size + buffer, col_size) - col_off
+
+    window = Window(col_off, row_off, window_width, window_height)
+
+    raw_data = np.empty((window_height, window_width, 10), dtype="u2")
+
+    for i, file_path in enumerate(img_paths):
+        with rasterio.open(file_path) as src:
+            band_data = src.read(1, window=window)
+            raw_data[:, :, i] = band_data
+
+    raw_data = raw_data.astype(np.float32) * scale
+
+    cloud_detector = S2PixelCloudDetector(threshold=0.4, average_over=1, dilation_size=1, all_bands=False)
+    cloud_mask = cloud_detector.get_cloud_masks(raw_data[np.newaxis, ...])
+
+    # crop original tile by removing buffer
+    start_row = row - row_off
+    start_col = col - col_off
+    end_row = start_row + min(tile_size, row_size - row)
+    end_col = start_col + min(tile_size, col_size - col)
+
+    original_tile = cloud_mask[0][start_row:end_row, start_col:end_col]
+
+    return (row, col, original_tile)
+
+
+def cloud_detect(img_paths: List[str],
+                 output_file_path: str,
+                 num_workers=None,
+                 progress = None):
+    t1 = time.time()
+    predict_task = None
+    if progress:
+        predict_task = progress.add_task(f"[cyan]Starting cloud detection")
+
+    col_size, row_size = preinference_check(img_paths)
+    tile_size=1024
+    buffer = 64
+
+    if predict_task is not None:
+        progress.update(predict_task, description="[cyan]Opening first image to get metadata")
+
+    with rasterio.open(img_paths[0]) as src:
+        crs = src.crs
+        dst_transform = src.transform
+
+    if predict_task is not None:
+        progress.update(predict_task, description=f"[cyan]Creating output file: {output_file_path}")
+
+    with rasterio.open(output_file_path,
+                       mode='w',
+                       driver="GTiff",
+                       dtype='float32',
+                       width=col_size,
+                       height=row_size,
+                       crs=crs,
+                       transform=dst_transform,
+                       count=1,
+                       compress='ZSTD',
+                       tiled=True) as dst:
+
+        tile_jobs = [
+            (row, col)
+            for row in range(0, row_size, tile_size)
+            for col in range(0, col_size, tile_size)
+        ]
+
+        if predict_task:
+            progress.update(predict_task, description=f"[cyan]Running cloud detection for {len(tile_jobs)} tiles", total=len(tile_jobs))
+
+        write_lock = threading.Lock()
+
+        if num_workers is None:
+            num_workers = psutil.cpu_count(logical=False)
+
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            job_iter = iter(tile_jobs)
+            running_futures = {}
+
+            # add first batch to process
+            for _ in range(num_workers):
+                row, col = next(job_iter)
+                task_id = progress.add_task(f"[green]Processing tile ({row}, {col})", total=None) if progress else None
+                fut = executor.submit(process_tile, row, col, img_paths,
+                                      buffer, row_size, col_size,
+                                      tile_size)
+                running_futures[fut] = (row, col, task_id)
+
+            while running_futures:
+                # wait for any future to complete
+                done, _ = concurrent.futures.wait(running_futures, return_when=concurrent.futures.FIRST_COMPLETED)
+
+                for fut in done:
+                    row, col, task_id = running_futures.pop(fut)
+                    row, col, original_tile = fut.result()
+
+                    with write_lock:
+                        dst.write(original_tile.astype(np.float32), 1,
+                                  window=Window(col, row, min(tile_size, col_size - col), min(tile_size, row_size - row)))
+
+                    if progress:
+                        if predict_task:
+                            progress.update(predict_task, advance=1)
+                        if task_id:
+                            progress.remove_task(task_id)
+
+                    # add next job
+                    try:
+                        row, col = next(job_iter)
+                        task_id = progress.add_task(f"[green]Processing tile ({row}, {col})", total=None) if progress else None
+                        fut = executor.submit(process_tile, row, col, img_paths,
+                                              buffer, row_size, col_size,
+                                              tile_size)
+                        running_futures[fut] = (row, col, task_id)
+                    except KeyboardInterrupt:
+                        logger.info("Cloud detection interrupted by user. Cancelling tasks..")
+                        executor.shutdown(wait=True, cancel_futures=True)
+                        raise
+                    except StopIteration:
+                        continue
+
+    t2 = time.time()
+    logger.debug(f"total time of cloud detection: {t2 - t1}")
+
+    if predict_task is not None:
+        progress.update(predict_task, description=f"[cyan]Cloud detection process completed successfully")
+        progress.remove_task(predict_task)
+    return output_file_path
+
+
+
+if __name__ == "__main__":
+    img_paths = ['/data/sentinel_tests/MGRS-35MRT/B01.tif', '/data/sentinel_tests/MGRS-35MRT/B02.tif',
+                 '/data/sentinel_tests/MGRS-35MRT/B04.tif', '/data/sentinel_tests/MGRS-35MRT/B05.tif',
+                 '/data/sentinel_tests/MGRS-35MRT/B08.tif', '/data/sentinel_tests/MGRS-35MRT/B8A.tif',
+                 '/data/sentinel_tests/MGRS-35MRT/B09.tif', '/data/sentinel_tests/MGRS-35MRT/B10.tif',
+                 '/data/sentinel_tests/MGRS-35MRT/B11.tif', '/data/sentinel_tests/MGRS-35MRT/B12.tif']
+
+    output_file_path="/data/sentinel_tests/MGRS-35MRT/cloud.tif"
+
+    with Progress() as progress:
+        t1 = time.time()
+        cloud_detect(img_paths=img_paths, output_file_path=output_file_path, progress=progress)
+        t2 = time.time()
+
+        logger.info(f"prediction time: {t2 - t1}")
+
+

--- a/rapida/components/landuse/constants.py
+++ b/rapida/components/landuse/constants.py
@@ -14,10 +14,19 @@ STAC_MAP = {
     'earth-search': 'https://earth-search.aws.element84.com/v1'
 }
 
-needed_assets = (
-    'B02', 'B03', 'B04', 'B05', 'B06', 'B07', 'B08', 'B11', 'B12'
-)
-earth_search_assets = (
-    'blue', 'green', 'red', 'rededge1', 'rededge2', 'rededge3', 'nir', 'swir16', 'swir22'
-)
-SENTINEL2_ASSET_MAP = dict(zip(earth_search_assets, needed_assets))
+# mapping asset name and band name
+SENTINEL2_ASSET_MAP = {
+    "coastal": "B01", # cloud
+    "blue": "B02", # land use, cloud
+    "green": "B03", # land use
+    "red": "B04", # land use, cloud
+    "rededge1": "B05", # land use, cloud
+    "rededge2": "B06", # land use
+    "rededge3": "B07", # land use
+    "nir": "B08", # land use, cloud
+    "nir08": "B8A", # cloud
+    "nir09": "B09", # cloud
+    "cirrus": "B10", # cloud
+    "swir16": "B11", # land use, cloud
+    "swir22": "B12", # land use, cloud
+}

--- a/rapida/components/landuse/download.py
+++ b/rapida/components/landuse/download.py
@@ -53,7 +53,6 @@ async def download_stac(
     output_file: str,
     target_year: int,
     target_month:int,
-    target_assets: dict[str, str],
     target_srs,
     progress: Progress = None,
     max_workers: int = 2,
@@ -67,7 +66,6 @@ async def download_stac(
     :param polygons_layer_name: name of layer polygon layer in geopackage to mask
     :param output_file: output file path
     :param target_year: target year
-    :param target_assets: target assets.
     :param target_srs: target projection CRS
     :param progress: rich progress object
     :param max_workers: maximum number of workers to download JP2 file concurrently
@@ -91,7 +89,6 @@ async def download_stac(
                       target_year=target_year,
                       target_month=target_month,
                       duration=12,
-                      target_assets=target_assets,
                       progress=progress,)
 
     tmp_cutline_path = make_buffer_polygon(geopackage_file_path, polygons_layer_name)
@@ -136,8 +133,12 @@ async def download_stac(
                 if predict_task is None and progress:
                     predict_task = progress.add_task("[cyan]Predicting...", total=len(sentinel_items))
 
-            progress.update(predict_task, description=f"[cyan]Predicting {item.item.id}")
+            progress.update(predict_task, description=f"[cyan]Creating cloud mask {item.item.id}")
+            item.detect_cloud(progress=progress)
+
+            progress.update(predict_task, description=f"[cyan]Predicting landuse {item.item.id}")
             item.predict(progress=progress)
+
             completed_items.append(item)
             progress.update(predict_task, advance=1)
             predict_queue.task_done()

--- a/rapida/components/landuse/download.py
+++ b/rapida/components/landuse/download.py
@@ -55,7 +55,7 @@ async def download_stac(
     target_month:int,
     target_srs,
     progress: Progress = None,
-    max_workers: int = 2,
+    max_workers: int = 1,
 ):
     """
     download STAC data from Earth Search to create tiff file for each asset (eg, B02, B03) required

--- a/rapida/components/landuse/sentinel_item.py
+++ b/rapida/components/landuse/sentinel_item.py
@@ -46,12 +46,9 @@ class SentinelItem(object):
     @property
     def id(self)->str:
         """
-        ID for the class instance. It uses grid:code for unique ID.
+        ID for the class instance. It uses item ID of STAC
         """
-        tile_id = self._item.properties.get("grid:code")
-        if tile_id is None:
-            tile_id = self._item.id
-        return tile_id
+        return self._item.id
 
     @property
     def target_asset(self) -> dict[str, str]:

--- a/rapida/components/landuse/stac_collection.py
+++ b/rapida/components/landuse/stac_collection.py
@@ -12,6 +12,7 @@ import numpy as np
 import shapely
 from shapely.geometry import Point, MultiPoint, Polygon
 
+from rapida.components.landuse.constants import SENTINEL2_ASSET_MAP
 from rapida.util.setup_logger import setup_logger
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ class StacCollection(object):
                      collection_id: str,
                      target_year: int,
                      target_month: int,
-                     target_assets: dict[str, str],
+                     target_assets: dict[str, str] = SENTINEL2_ASSET_MAP,
                      duration: int = 12,
                      tile_id_prop_name: str = "grid:code",
                      max_workers: int = 5,
@@ -251,7 +252,7 @@ if __name__ == '__main__':
     setup_logger()
 
     stac_url = "https://earth-search.aws.element84.com/v1"
-    mask_file = "/data/kigali/data/kigali.gpkg"
+    mask_file = "/data/kigali_small/data/kigali_small.gpkg"
     mask_layer = "polygons"
     collection_id = "sentinel-2-l1c"
 
@@ -259,21 +260,12 @@ if __name__ == '__main__':
                                      mask_file=mask_file,
                                      mask_layer=mask_layer)
 
-    needed_assets = (
-        'B02', 'B03', 'B04', 'B05', 'B06', 'B07', 'B08', 'B11', 'B12'
-    )
-    earth_search_assets = (
-        'blue', 'green', 'red', 'rededge1', 'rededge2', 'rededge3', 'nir', 'swir16', 'swir22'
-    )
-    asset_map = dict(zip(earth_search_assets, needed_assets))
-
     with Progress() as progress:
         latest_per_tile = stac_collection.search_items(
             collection_id=collection_id,
             target_year=2025,
             target_month=4,
             duration=12,
-            target_assets=asset_map,
             progress=progress, )
 
         logger.info(latest_per_tile)


### PR DESCRIPTION
closes #291

- download stac item for each item ID other than downloading by UTM grid
- predict cloud mask from sentinel bands (`cloud_mask.tif`)
- predict land use (`landuse_prediction.tif.tmp`)
- remove cloud from `landuse_prediction.tif.tmp` by `cloud_mask.tif`. output file is `landuse_prediction.tif`
- optimise searching strategy. Check the coverage of each STAC item and the project area. If more than 10 percent is covering project area, it will be downloaded. otherwise, it will be skipped to download.