### PR TITLE
fix: introducing multistage build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
           file: Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            PRODUCTION=true
+          target: prod
           outputs: type=docker,dest=${{ runner.temp }}/myimage.tar
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,23 @@ After building dev version image, you can enter to the shell through the below c
 
 ```shell
 make shell
+
+# after entering to the shell
+pipenv shell # enter pipenv environment
+rapida init # initialize rapida command
+```
+
+Note. You may need to edit [docker-compose.dev.yaml](./docker-compose.dev.yaml) to mount volumes from your local storage.
+
+```yaml
+    volumes:
+      - ./Makefile:/rapida/Makefile
+      - ./rapida:/rapida/rapida # mount rapida folder to container
+      - ./tests:/rapida/tests
+      # uncomment to mount token info from local
+      - ~/.rapida:/root/.rapida # <- uncomment this if you want to keep authenticated credentials
+      # uncomment to mount data folder from local
+      - ./data:/data # <- uncomment and modify this if you want to mount /data folder from local storage
 ```
 
 - Destroy dev Docker image
@@ -31,3 +48,30 @@ make shell
 ```shell
 make down
 ```
+
+- Develop in arm64 environment such as Apple Silcon
+
+Uncomment `platform` in `docker-compose.dev.yaml`
+
+```diff
+-    # platform: linux/amd64
++    platform: linux/amd64
+```
+
+## Building for production Docker image
+
+- Using Makefile command
+
+```shell
+make build-prod
+```
+
+- Using `docker build`
+
+```shell
+docker build . --target=prod -t rapida 
+```
+
+Note. `--target=prod` option is required to build Docker image for production.
+
+Real production image is built automatically by GitHub Actions, and will be pushed into both GitHub Container Registry and Azure Container Registry.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing Guidelines
+
+This document contains a set of guidelines to help developers during the contribution process.
+
+## Local development
+
+We recommend you to use Docker to develop rapida tool in your local computer.
+
+[docker-compose.dev.yaml](./docker-compose.dev.yaml) can be used for local development while [docker-compose.yaml](./docker-compose.yaml) is for production Docker image generation.
+
+If you are in either Linux or Mac environment, you can use Makefile commands.
+
+- Build dev Docker image
+
+This command will build Docker image until `dev` state.
+
+```shell
+make build
+```
+
+- Enter to shell in Docker container
+
+After building dev version image, you can enter to the shell through the below command.
+
+```shell
+make shell
+```
+
+- Destroy dev Docker image
+
+```shell
+make down
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,15 +49,6 @@ Note. You may need to edit [docker-compose.dev.yaml](./docker-compose.dev.yaml) 
 make down
 ```
 
-- Develop in arm64 environment such as Apple Silcon
-
-Uncomment `platform` in `docker-compose.dev.yaml`
-
-```diff
--    # platform: linux/amd64
-+    platform: linux/amd64
-```
-
 ## Building for production Docker image
 
 - Using Makefile command

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install app dependencies
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3-pip python3-gdal pipenv gcc git cmake libgeos-dev && \
+    apt-get install -y --no-install-recommends \
+      python3-pip \
+      python3-gdal \
+      python3-dev \
+      pipenv \
+      gcc \
+      g++ \
+      git \
+      cmake \
+      libgeos-dev && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install playwright --break-system-packages && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     make -j$(nproc)
 
 # Stage 2: Final image based on GDAL
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.10.0
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.10.0 AS base
 
 
 # Set environment vars
@@ -42,7 +42,16 @@ RUN pipenv --python 3 --site-packages
 
 COPY . .
 
+# Docker image for development
+FROM base AS dev
+
+RUN pipenv run pip install -e .
+
+# Docker image for production
+FROM base AS prod
+
 RUN pipenv run pip install .
+
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,5 @@
 .PHONY: help test build build-prod down shell
 
-# Detect host machine architecture
-ARCH := $(shell uname -m)
-TARGET ?= dev
-
-# Set platform for ARM64 environment
-ifeq ($(ARCH),arm64)
-    PLATFORM_ARG = --platform linux/amd64
-    COMPOSE_PLATFORM = DOCKER_DEFAULT_PLATFORM=linux/amd64
-else
-    PLATFORM_ARG =
-    COMPOSE_PLATFORM =
-endif
-
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  shell            to shell in dev mode"
@@ -20,18 +7,14 @@ help:
 	@echo "  build            to build docker image"
 	@echo "  build-prod       to build production docker image"
 	@echo "  down             to destroy docker containers"
-	@echo ""
-	@echo "Detected architecture: $(ARCH)"
-ifneq ($(PLATFORM_ARG),)
-	@echo "Platform override: linux/amd64"
-endif
+
 
 shell:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@echo "Shelling in dev mode"
 	@echo "------------------------------------------------------------------"
-	$(COMPOSE_PLATFORM) docker compose -f docker-compose.dev.yaml run --remove-orphans --entrypoint /bin/bash rapida-dev
+	docker compose -f docker-compose.dev.yaml run --remove-orphans --entrypoint /bin/bash rapida-dev
 
 
 test:
@@ -46,20 +29,20 @@ build:
 	@echo "------------------------------------------------------------------"
 	@echo "Building Docker image"
 	@echo "------------------------------------------------------------------"
-	$(COMPOSE_PLATFORM) docker compose -f docker-compose.dev.yaml build
+	docker compose -f docker-compose.dev.yaml build
 
 build-prod:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@echo "Building Production Docker image"
 	@echo "------------------------------------------------------------------"
-	$(COMPOSE_PLATFORM) docker compose -f docker-compose.yaml build
+	docker compose -f docker-compose.yaml build
 
 down:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@echo "Destroy docker containers"
 	@echo "------------------------------------------------------------------"
-	$(COMPOSE_PLATFORM) docker compose -f docker-compose.dev.yaml down
+	docker compose -f docker-compose.dev.yaml down
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,37 @@
-.PHONY: help test build down shell
+.PHONY: help test build build-prod down shell
+
+# Detect host machine architecture
+ARCH := $(shell uname -m)
+TARGET ?= dev
+
+# Set platform for ARM64 environment
+ifeq ($(ARCH),arm64)
+    PLATFORM_ARG = --platform linux/amd64
+    COMPOSE_PLATFORM = DOCKER_DEFAULT_PLATFORM=linux/amd64
+else
+    PLATFORM_ARG =
+    COMPOSE_PLATFORM =
+endif
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  shell            to shell in dev mode"
 	@echo "  test             to execute test cases"
 	@echo "  build            to build docker image"
+	@echo "  build-prod       to build production docker image"
 	@echo "  down             to destroy docker containers"
-
+	@echo ""
+	@echo "Detected architecture: $(ARCH)"
+ifneq ($(PLATFORM_ARG),)
+	@echo "Platform override: linux/amd64"
+endif
 
 shell:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@echo "Shelling in dev mode"
 	@echo "------------------------------------------------------------------"
-	docker compose -f docker-compose.yaml run --remove-orphans --entrypoint /bin/bash rapida
+	$(COMPOSE_PLATFORM) docker compose -f docker-compose.dev.yaml run --remove-orphans --entrypoint /bin/bash rapida-dev
 
 
 test:
@@ -28,13 +46,20 @@ build:
 	@echo "------------------------------------------------------------------"
 	@echo "Building Docker image"
 	@echo "------------------------------------------------------------------"
-	docker compose -f docker-compose.yaml build --build-arg PRODUCTION=$(PRODUCTION)
+	$(COMPOSE_PLATFORM) docker compose -f docker-compose.dev.yaml build
+
+build-prod:
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Building Production Docker image"
+	@echo "------------------------------------------------------------------"
+	$(COMPOSE_PLATFORM) docker compose -f docker-compose.yaml build
 
 down:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@echo "Destroy docker containers"
 	@echo "------------------------------------------------------------------"
-	docker compose -f docker-compose.yaml down
+	$(COMPOSE_PLATFORM) docker compose -f docker-compose.dev.yaml down
 
 

--- a/README.md
+++ b/README.md
@@ -680,3 +680,6 @@ and as a result we recommend Windows users to use [WSL](https://learn.microsoft.
 > [IMPORTANT]
 > Make sure to set the core resources available to the container(CPU, RAM) according to your own system capabilities
    
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for more information about developing rapida in local computer.

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -5,13 +5,14 @@ services:
       dockerfile: ./Dockerfile
       target: dev
     image: rapida-dev:latest
+    # platform: linux/amd64
     volumes:
       - ./Makefile:/rapida/Makefile
-      - ./rapida:/rapida/rapida # mount app folder to container
+      - ./rapida:/rapida/rapida # mount rapida folder to container
       - ./tests:/rapida/tests
       # uncomment to mount token info from local
-#      - ~/.rapida:/root/.rapida
+      # - ~/.rapida:/root/.rapida
       # uncomment to mount data folder from local
-#      - ./data:/data
+      # - ./data:/data
     env_file:
       - .env

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,17 @@
+services:
+  rapida-dev:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      target: dev
+    image: rapida-dev:latest
+    volumes:
+      - ./Makefile:/rapida/Makefile
+      - ./rapida:/rapida/rapida # mount app folder to container
+      - ./tests:/rapida/tests
+      # uncomment to mount token info from local
+#      - ~/.rapida:/root/.rapida
+      # uncomment to mount data folder from local
+#      - ./data:/data
+    env_file:
+      - .env

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -5,7 +5,6 @@ services:
       dockerfile: ./Dockerfile
       target: dev
     image: rapida-dev:latest
-    # platform: linux/amd64
     volumes:
       - ./Makefile:/rapida/Makefile
       - ./rapida:/rapida/rapida # mount rapida folder to container

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,5 +3,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
+      target: prod
     image: rapida:latest
-
+    env_file:
+      - .env


### PR DESCRIPTION
introducing multistage build to differentiate dev and prod image generation.

- Installation of rapida package is split into `dev` and `prod` stage
  - if `--target=dev` is used to build, rapida is installed with `-e` which can be live updated from mounted code
  - if `--target=prod` is used to build, rapida is installed without `-e` for production
- In Apple Silicon environment, some dependencies like `rasterio` and `exactextract` needs to be built from source code to generate whl. This compiling process failed because of lack of some package installation. I added `python3-dev` and `g++` to be installed in Dockerfile.
  - Because of this above change, now arm64 docker image can be built for Mac environment. the performance of rapida in Mac becomes significantly faster.
- Added `CONTRIBUTING.md` to document some tips of local development.