### PR TITLE
feat: added --cloud-cover/-cc option in assess command to set minimum cloud cover rate for landuse

### DIFF
--- a/rapida/cli/assess.py
+++ b/rapida/cli/assess.py
@@ -120,6 +120,8 @@ def build_variable_help():
               show_default=True,help=f'The year for which to compute population and landuse' )
 @click.option('--month', '-m', required=False, type=int, multiple=False,default=None,
               show_default=True,help=f"Optional. The end month for which to compute landuse. \nIf this is used together with --year, it searches data until target year and month for the last 6 months. \nIf this is used without --year, and it is future month, current month is used as end month.")
+@click.option('--cloud-cover', '-cc', required=False, type=int, multiple=False, default=5,
+              show_default=True,help=f"Optional. Minimum cloud cover rate to search items for landuse component.")
 @click.option('-p', '--project',
               default=None,
               type=click.Path(file_okay=False, dir_okay=True, resolve_path=True),
@@ -132,7 +134,7 @@ def build_variable_help():
               help="Set log level to debug"
               )
 @click.pass_context
-def assess(ctx, all=False, components=None,  variables=None, year=None, month=None, project: str = None, force=False, debug=False):
+def assess(ctx, all=False, components=None,  variables=None, year=None, month=None, cloud_cover=None, project: str = None, force=False, debug=False):
     """
     Assess/evaluate a specific geospatial exposure components/variables
 
@@ -210,7 +212,12 @@ def assess(ctx, all=False, components=None,  variables=None, year=None, month=No
                 cls = import_class(fqcn=fqcn)
                 component = cls()
 
-                component(progress=progress, variables=variables, target_year=year, target_month=month, force=force)
+                component(progress=progress,
+                          variables=variables,
+                          target_year=year,
+                          target_month=month,
+                          cloud_cover=cloud_cover,
+                          force=force)
 
 
 

--- a/rapida/components/landuse/__init__.py
+++ b/rapida/components/landuse/__init__.py
@@ -23,7 +23,7 @@ logger = logging.getLogger('rapida')
 
 
 class LanduseComponent(Component):
-    def __call__(self, variables: List[str], target_year: int=None, target_month: int=None, **kwargs):
+    def __call__(self, variables: List[str], target_year: int=None, target_month: int=None, cloud_cover:int = None, **kwargs):
         if not variables:
             variables = self.variables
         else:
@@ -43,6 +43,7 @@ class LanduseComponent(Component):
                     component=self.component_name,
                     target_year=target_year,
                     target_month=target_month,
+                    cloud_cover=cloud_cover,
                     **var_data
                 )
                 v(**kwargs)
@@ -135,6 +136,7 @@ class LanduseVariable(Variable):
                           target_year=self.target_year,
                           target_month=self.target_month,
                           target_srs=project.target_srs,
+                          cloud_cover=self.cloud_cover,
                           progress=progress))
 
 

--- a/rapida/components/landuse/download.py
+++ b/rapida/components/landuse/download.py
@@ -54,6 +54,7 @@ async def download_stac(
     target_year: int,
     target_month:int,
     target_srs,
+    cloud_cover: int = 5,
     progress: Progress = None,
     max_workers: int = 1,
 ):
@@ -67,6 +68,7 @@ async def download_stac(
     :param output_file: output file path
     :param target_year: target year
     :param target_srs: target projection CRS
+    :param cloud_cover: how much minimum cloud cover rate to search for. Default is 5.
     :param progress: rich progress object
     :param max_workers: maximum number of workers to download JP2 file concurrently
     :return the list of output files
@@ -89,6 +91,7 @@ async def download_stac(
                       target_year=target_year,
                       target_month=target_month,
                       duration=12,
+                      cloud_cover=cloud_cover,
                       progress=progress,)
 
     tmp_cutline_path = make_buffer_polygon(geopackage_file_path, polygons_layer_name)


### PR DESCRIPTION
fixes #416 

latest help message for assess command

```shell
 rapida assess -h
Usage: rapida assess [OPTIONS]

  Assess/evaluate a specific geospatial exposure components/variables

  `-a/--all` option to assess all components (it may take longer time).

  `-c/--component` to assess only specific components.

  `-v/--variable` to assess only specific variables. If a variable is
  specified, but it is not in specified components, the variable will be
  ignored.

  `-p/--project` to assess in a specific project folder other than current
  directory.

  As default, this command tries to avoid download/compute again if they
  already exist. If you wish to redownload or recompute by force, use
  `-f/--force` flag explicitly.

  Usage:

  rapida assess --all: assess all components

  rapida assess -c rwi: assess RWI component only.

  rapida assess -c rwi -c population: assess RWI and population component only

  rapida assess -c population -v male_total -v female_total: assess only male
  and female total population.

  rapida assess -c rwi -p ./data/sample_project: assess RWI component for
  RAPIDA project stored at sample_project folder.

Options:
  -a, --all                       compute all components and variables if this
                                  option is set
  -c, --components [gdp|landuse|rwi|elegrid|deprivation|buildings|population|roads]
                                  One or more components to be assessed. Valid
                                  input example: -c gdp -c landuse
  -v, --variables TEXT            The variable/s to be assessed. Will be
                                  filtered by selected components. Available
                                  variables per component:
                                  
                                  gdp (gdp_sum, gdp_min, gdp_max, gdp_mean)
                                  
                                  landuse (crops_area, built_area)
                                  
                                  rwi (rwi_max, rwi_mean, rwi_min)
                                  
                                  elegrid (elegrid_length, elegrid_density)
                                  
                                  deprivation (depriv_min, depriv_max,
                                  depriv_mean)
                                  
                                  buildings (buildings_area, nbuildings)
                                  
                                  population (male_active, male_elderly,
                                  female_child, male_total, dependency,
                                  male_child, child_total, female_total,
                                  child_dependency, active_total,
                                  elderly_total, total, female_active,
                                  female_elderly, elderly_dependency)
                                  
                                  roads (roads_length, roads_density)
  -y, --year INTEGER              The year for which to compute population and
                                  landuse  [default: 2025]
  -m, --month INTEGER             Optional. The end month for which to compute
                                  landuse.  If this is used together with
                                  --year, it searches data until target year
                                  and month for the last 6 months.  If this is
                                  used without --year, and it is future month,
                                  current month is used as end month.
  -cc, --cloud-cover INTEGER      Optional. Minimum cloud cover rate to search
                                  items for landuse component.  [default: 5]
  -p, --project DIRECTORY         Optional. A project folder with rapida.json
                                  can be specified. If not, current directory
                                  is considered as a project folder.
  -f, --force                     Force assess components. Downloaded data or
                                  computed data will be ignored and
                                  recomputed.
  --debug                         Set log level to debug
  -h, --help                      Show this message and exit.

```